### PR TITLE
Add arguments to the query in the report

### DIFF
--- a/lib/rspec/sqlimit/counter.rb
+++ b/lib/rspec/sqlimit/counter.rb
@@ -31,8 +31,17 @@ module RSpec::SQLimit
     def callback
       @callback ||= lambda do |_name, start, finish, _message_id, values|
         return if %w(CACHE SCHEMA).include? values[:name]
-        queries << { sql: values[:sql], duration: (finish - start) * 1_000 }
+        queries << { sql: replace_args(values[:sql], values[:binds]),
+                     duration: (finish - start) * 1_000 }
       end
+    end
+
+    def replace_args(query, args)
+      result = query
+      args.each do |arg|
+        result = query.gsub("?", %("#{arg.value}"))
+      end
+      result
     end
   end
 end

--- a/spec/rspec/sqlimit_spec.rb
+++ b/spec/rspec/sqlimit_spec.rb
@@ -70,7 +70,7 @@ describe "exceed_query_limit" do
 
       describe '.delete' do
         it 'works when actual number of queries is below the limit' do
-          expect { user.destroy }.not_to exceed_query_limit(0).with(/DELETE/)
+          expect { user.destroy }.not_to exceed_query_limit(1).with(/DELETE/)
         end
       end
     end

--- a/spec/rspec/sqlimit_spec.rb
+++ b/spec/rspec/sqlimit_spec.rb
@@ -31,5 +31,48 @@ describe "exceed_query_limit" do
     it 'works when nil is used' do
       expect { User.create id: nil }.to exceed_query_limit(0).with(/INSERT/)
     end
+
+    context 'for collection' do
+      before do
+        3.times { User.create }
+      end
+      it 'works when actual number of queries exceeds the limit' do
+        expect { User.all.to_a }.to exceed_query_limit(0).with(/SELECT/)
+      end
+
+      it 'works when actual number of queries is below the limit' do
+        expect { User.all.to_a }.not_to exceed_query_limit(1).with(/SELECT/)
+      end
+
+      it 'works when array is used as a restrcition' do
+        expect { User.where(id: [1, 2, 3]).to_a }.to exceed_query_limit(0)
+                                                         .with(/SELECT/)
+      end
+
+      it 'works when array is used as a restrcition negative case' do
+        expect { User.where(id: [1, 2, 3]).to_a }.not_to exceed_query_limit(1)
+                                                         .with(/SELECT/)
+      end
+    end
+
+    context 'update or delete queries' do
+      let(:user) { User.create }
+      describe '.update' do
+        it 'works when actual number of queries is exceeds the limit' do
+          expect { user.update(id: 2) }.to exceed_query_limit(0).with(/UPDATE/)
+        end
+
+        it 'works when actual number of queries is below the limit' do
+          expect { user.update(id: 2) }.not_to exceed_query_limit(1)
+                                                   .with(/UPDATE/)
+        end
+      end
+
+      describe '.destroy' do
+        it 'works when actual number of queries is below the limit' do
+          expect { user.destroy }.not_to exceed_query_limit(0).with(/UPDATE/)
+        end
+      end
+    end
   end
 end

--- a/spec/rspec/sqlimit_spec.rb
+++ b/spec/rspec/sqlimit_spec.rb
@@ -27,5 +27,9 @@ describe "exceed_query_limit" do
     it "works when actual number of queries exceeds the limit" do
       expect { User.create id: 3 }.to exceed_query_limit(0).with(/INSERT/)
     end
+
+    it 'works when nil is used' do
+      expect { User.create id: nil }.to exceed_query_limit(0).with(/INSERT/)
+    end
   end
 end

--- a/spec/rspec/sqlimit_spec.rb
+++ b/spec/rspec/sqlimit_spec.rb
@@ -72,6 +72,10 @@ describe "exceed_query_limit" do
         it 'works when actual number of queries is below the limit' do
           expect { user.destroy }.not_to exceed_query_limit(1).with(/DELETE/)
         end
+        
+        it 'works when actual number of queries is exceeds the limit' do
+          expect { user.destroy }.to exceed_query_limit(0).with(/DELETE/)
+        end
       end
     end
   end

--- a/spec/rspec/sqlimit_spec.rb
+++ b/spec/rspec/sqlimit_spec.rb
@@ -68,9 +68,9 @@ describe "exceed_query_limit" do
         end
       end
 
-      describe '.destroy' do
+      describe '.delete' do
         it 'works when actual number of queries is below the limit' do
-          expect { user.destroy }.not_to exceed_query_limit(0).with(/UPDATE/)
+          expect { user.destroy }.not_to exceed_query_limit(0).with(/DELETE/)
         end
       end
     end


### PR DESCRIPTION
Good evening! When writing spes, I ran into the problem that all SELECT queries returned to me  `No queries were invoked`  
for example

```
it 'name spec' do
      User.create
      expect { User.all }.to exceed_query_limit(0).with(/SELECT/)
end
```
```
it 'name spec' do
      5.times  { User.create }
      expect { User.where(id:1, 2, 3, 4, 5) }.to exceed_query_limit(0).with(/SELECT/)
end
```
please, сan tell me what I'm doing wrong?



Update and destruction work correctly if important i can write specs for this cases
 
```   
       Expected to run maximum 0 queries that match (?-mix:UPDATE)
       The following 1 queries were invoked among others (see mark ->):
          1) SELECT "users".* FROM "users" (0.277 ms)
          2) begin transaction (0.144 ms)
       -> 3) UPDATE "users" SET "id" = "1" WHERE "users"."id" = "1" (0.332 ms)
          4) commit transaction (96.658 ms)
```
```
Expected to run more than 0 queries that match (?-mix:DESTROY)
       The following 0 queries were invoked among others (see mark ->):
          1) SELECT  "users".* FROM "users" ORDER BY "users"."id" DESC LIMIT "1" (0.347 ms)
          2) begin transaction (0.086 ms)
          3) DELETE FROM "users" WHERE "users"."id" = "1" (0.293 ms)
          4) commit transaction (83.087 ms)
```
