### PR TITLE
Introduce exceed_query_limits to provide multiple limits

### DIFF
--- a/lib/rspec/sqlimit.rb
+++ b/lib/rspec/sqlimit.rb
@@ -44,4 +44,60 @@ module RSpec
       MESSAGE
     end
   end
+
+  Matchers.define :exceed_query_limits do |options|
+    match do |block|
+      @results = []
+      options.each_pair do |key, expected|
+        matcher = key == :total ? nil : Regexp.new("^#{key.to_s.upcase.gsub(/_/, " ")}")
+        counter = RSpec::SQLimit::Counter[matcher, block]
+        @results << ExceedQueryLimitsResult.new(counter, expected)
+      end
+      @results.any?(&:more_than_expected?)
+    end
+
+    failure_message do
+      @results.select(&:less_than_expected?).first.message
+    end
+
+    failure_message_when_negated do
+      @results.select(&:more_than_expected?).first.negated_message
+    end
+
+    supports_block_expectations
+  end
+  
+  private
+  class ExceedQueryLimitsResult
+    attr_reader :counter
+    attr_reader :expected
+    def initialize counter, expected
+      @counter = counter
+      @expected = expected
+    end
+
+    def more_than_expected?
+      @counter.count > expected
+    end
+
+    def less_than_expected?
+      @counter.count <= expected
+    end
+
+    def negated_message
+      message true
+    end
+
+    def message(negation = false)
+      reporter    = RSpec::SQLimit::Reporter.new(@counter)
+      condition   = negation ? "maximum" : "more than"
+      restriction = " that match #{reporter.matcher}" if reporter.matcher
+
+      <<-MESSAGE.gsub(/ +\|/, "")
+        |Expected to run #{condition} #{@expected} queries#{restriction}
+        |#{reporter.call}
+      MESSAGE
+    end
+  end
+
 end

--- a/spec/rspec/sqlimit_spec.rb
+++ b/spec/rspec/sqlimit_spec.rb
@@ -45,3 +45,77 @@ describe "exceed_query_limit" do
     end
   end
 end
+
+describe "#exceed_query_limits" do
+  let(:select_sql) { "SELECT * FROM Users" }
+  let(:delete_sql) { "DELETE FROM Users WHERE id = 42" }
+  let(:update_sql) { "UPDATE Users SET id = 42 WHERE id = 0" }
+
+  context "not negated" do
+    it "works with single queries" do
+      expect { User.create id: nil }.to exceed_query_limits(
+        insert: 0
+      )
+    end
+
+    [
+      { delete: 0, select: 2 },
+      { delete: 1, select: 1 },
+      { delete: 0, select: 1, total: 3 }
+    ].each do |limits|
+      it "works when the limits are #{limits} and the queries are SELECT, DELETE, SELECT" do
+        expect do
+          ActiveRecord::Base.connection.execute(select_sql)
+          ActiveRecord::Base.connection.execute(delete_sql)
+          ActiveRecord::Base.connection.execute(select_sql)
+        end.to exceed_query_limits(limits)
+      end
+    end
+  end
+
+  context "negated" do
+    it "works with single queries" do
+      expect { User.create id: nil }.not_to exceed_query_limits(
+        insert: 1
+      )
+    end
+
+    it "works when the limit is { 2 SELECT, 1 DELETE, 3 total } and the calls are SELECT, DELETE, SELECT" do
+      expect do
+        ActiveRecord::Base.connection.execute(select_sql)
+        ActiveRecord::Base.connection.execute(delete_sql)
+        ActiveRecord::Base.connection.execute(select_sql)
+      end.not_to exceed_query_limits(
+        delete: 1,
+        select: 2,
+        total: 3
+      )
+    end
+
+    it "works when the limit is { 2 SELECT, 1 DELETE, 4 total } and the calls are SELECT, DELETE, SELECT, UPDATE" do
+      expect do
+        ActiveRecord::Base.connection.execute(select_sql)
+        ActiveRecord::Base.connection.execute(delete_sql)
+        ActiveRecord::Base.connection.execute(select_sql)
+        ActiveRecord::Base.connection.execute(update_sql)
+      end.not_to exceed_query_limits(
+        delete: 1,
+        select: 2,
+        total: 4
+      )
+    end
+
+    it "works when the limit is { 2 SELECT, 1 DELETE, 4 total } and the calls are SELECT, SELECT, UPDATE" do
+      p exceed_query_limits.method(:matches?).source_location
+      expect do
+        ActiveRecord::Base.connection.execute(select_sql)
+        ActiveRecord::Base.connection.execute(select_sql)
+        ActiveRecord::Base.connection.execute(update_sql)
+      end.not_to exceed_query_limits(
+        delete: 1,
+        select: 2,
+        total: 4
+      )
+    end
+  end
+end


### PR DESCRIPTION
Motivation
-------------
I found I was writing specs like:

```
block = proc {
  the_model.complex_mutation!
  the_model.save!
}

expect(block).not_to exceed_query_limit(1).with /^SELECT/
expect(block).not_to exceed_query_limit(1).with /^INSERT/
expect(block).not_to exceed_query_limit(4)
```

But now you can write:
-------------------
```
expect {
  the_model.complex_mutation!
  the_model.save!
} .not_to exceed_query_limits(
  select: 1,
  insert: 1,
  total: 4
)
```

This is a work in progress - among other things, I still need to:
  - update the README
  - I think there's a bug in what I've written (I've noticed it when using this in another project) -- I need to update my tests to reproduce it. 
  - The message generation is copy&pasted from `exceed_query_limit`, but should probably be extracted in a reusable way -- or even the whole `ExceedQueryLimitsResult` could probably be shared. 
  - The name maybe should be changed.. having it differ only by one character seems odd.

Let me know what you think -- I won't update the readme until I know you're interested in merging this. 