### PR TITLE
Bump v0.0.3

### DIFF
--- a/lib/rspec/sqlimit/version.rb
+++ b/lib/rspec/sqlimit/version.rb
@@ -1,0 +1,3 @@
+module RSpec::SQLimit
+  VERSION = '0.0.3'
+end

--- a/rspec-sqlimit.gemspec
+++ b/rspec-sqlimit.gemspec
@@ -1,6 +1,9 @@
+require_relative 'lib/rspec/sqlimit'
+require_relative 'lib/rspec/sqlimit/version'
+
 Gem::Specification.new do |gem|
   gem.name        = "rspec-sqlimit"
-  gem.version     = "0.0.2"
+  gem.version     = RSpec::SQLimit::VERSION
   gem.author      = "Andrew Kozin (nepalez)"
   gem.email       = "andrew.kozin@gmail.com"
   gem.homepage    = "https://github.com/nepalez/rspec-sqlimit"


### PR DESCRIPTION
Helps address [this](https://github.com/nepalez/rspec-sqlimit/issues/13) issue. If RubyGems is relatively up-to-date and you're signed in, you may be able to just merge this and `bundle exec rake release`.