### PR TITLE
Ignore cached queries

### DIFF
--- a/lib/rspec/sqlimit/counter.rb
+++ b/lib/rspec/sqlimit/counter.rb
@@ -31,6 +31,7 @@ module RSpec::SQLimit
     def callback
       @callback ||= lambda do |_name, start, finish, _message_id, values|
         return if %w(CACHE SCHEMA).include? values[:name]
+        return if cached_query?(values)
         queries << {
           sql: values[:sql],
           duration: (finish - start) * 1_000,
@@ -41,6 +42,10 @@ module RSpec::SQLimit
 
     def type_cast(binds)
       binds.map { |column, value| ActiveRecord::Base.connection.type_cast(value, column) }
+    end
+
+    def cached_query?(values)
+      values[:type_casted_binds].respond_to?(:call)
     end
   end
 end

--- a/spec/rspec/sqlimit/reporter_spec.rb
+++ b/spec/rspec/sqlimit/reporter_spec.rb
@@ -42,4 +42,21 @@ describe RSpec::SQLimit::Reporter do
       end
     end
   end
+
+  context 'activerecord query caching was enabled' do
+    let(:counter) { RSpec::SQLimit::Counter[nil, Proc.new{ queries }] }
+
+    let(:queries) do
+      User.cache do
+        User.where(id: 1).to_a
+        User.where(id: 1).to_a
+        User.where(id: [2, 3]).to_a
+        User.where(id: [2, 3]).to_a
+      end
+    end
+
+    it 'ignores cached queries' do
+      expect(subject.call).to include("2 queries were invoked")
+    end
+  end
 end


### PR DESCRIPTION
Given this expectation:
```ruby
queries = proc do
  User.cache do
    User.where(id: 1).to_a
    User.where(id: 1).to_a
  end
end

expect(&queries).not_to exceed_query_limit(0)
```
The resulting error message was unexpected:
```
Failure/Error: binds = query[:binds].any? ? "; #{query[:binds]} " : ''

NoMethodError:
  undefined method `any?' for #<Proc:0x00007fd408e059c8>
```
I previously reported this issue as #11, but I didn't know the cause back then.

This pull request will make the reporter show the query list instead. I also exclude all subsequent cached results from the total count and the query list.
```
Failure/Error: expect(&queries).not_to exceed_query_limit(0)

  Expected to run maximum 0 queries
  The following 1 queries were invoked:
     1) SELECT "users".* FROM "users" WHERE "users"."id" = ?; [1]  (0.151 ms)
```