### PR TITLE
Depend on ActiveRecord not Rails

### DIFF
--- a/rspec-sqlimit.gemspec
+++ b/rspec-sqlimit.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3"
 
-  gem.add_runtime_dependency "rails", "> 4.2", "< 7.0"
+  gem.add_runtime_dependency "activerecord", "> 4.2", "< 7.0"
   gem.add_runtime_dependency "rspec", "~> 3.0"
 
   gem.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
This allows using this gem with projects that use ActiveRecord but
don't use the full Rails suite. The ActiveSupport dependency is also
pulled by ActiveRecord itself.

fixes #17 